### PR TITLE
Now reads from stdin if no hosts.dat or --hostlist

### DIFF
--- a/horde/horde.py
+++ b/horde/horde.py
@@ -161,16 +161,15 @@ def local_ip():
 
 def hordemain():
     if not os.path.exists(opts['hosts']) and opts['hostlist'] is False:
-        sys.exit('ERROR: hosts file "%s" does not exist' % opts['hosts'])
-
-    if opts['hosts']:
+        hosts = [line.strip() for line in sys.stdin]
+    elif opts['hosts']:
         hosts = [line.strip() for line in open(opts['hosts'], 'r')]
-        # filter out comments and empty lines
-        hosts = [
-            host for host in hosts if not re.match("^#", host)
-            and host is not '']
     else:
         hosts = opts['hostlist'].split(',')
+    # filter out comments and empty lines
+    hosts = [host for host in hosts if not re.match("^#", host) and not host == '']
+    if len(hosts) == 0:
+      sys.exit('ERROR: No hosts provided.')
     # handles duplicates
     hosts = list(set(hosts))
     log.info("Running with options: %s" % opts)


### PR DESCRIPTION
Fixes two bugs:
- Junk being passed into `--hostlist` not being sanitized like other methods.  Fixed.
- Blank list being passed into `--hostlist` not being detected as an error.  Fixed.

Adds a feature:
- Reading the host list from `stdin` if hosts.dat and `--hostlist` is not provided in the arguments.

This was cherry picked from https://github.com/russss/Herd/pull/13.
